### PR TITLE
Exclude import statements from stats collection.

### DIFF
--- a/src/collect-stats.ts
+++ b/src/collect-stats.ts
@@ -37,7 +37,7 @@ export async function collectStats(
 
 async function getStatsForOne(path: string, name: string): Promise<number> {
   return new Promise<number>((resolve) => {
-    cp.exec(`grep -ro ${name} ${path} | wc -w`, (err, r) => {
+    cp.exec(`grep -rv 'import' ${path} | grep -o ${name} | wc -w`, (err, r) => {
       resolve(parseInt(r.trim(), 10));
     });
   });


### PR DESCRIPTION
This was returning in some files double the actual number as it counted the import statement as well as the use.